### PR TITLE
crontab: move to every 5

### DIFF
--- a/linux/every1/crontab.sh
+++ b/linux/every1/crontab.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-file="$BASE/crontab.txt"
-if test -f "$file"; then
-    crontab $file
-fi

--- a/linux/every5/crontab.sh
+++ b/linux/every5/crontab.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Double check to make sure that the crontab file is not empty before
+# replacing it (i.e., the "-s" option).
+file="$BASE/crontab.txt"
+if test -f "$file" -a -s "$file"; then
+    crontab $file
+fi


### PR DESCRIPTION
Doesn't make sense to update the crontab every minute if we only "git
pull" every 5 minutes.

Also, having the crontab script in the "every1" directory made a bit
of a race condition with the "git pull" script in the "every5"
directory.  I.e., the "git pull" could be running and in the act of
replacing the crontab.txt file when the crontab script runs and
replaces the crontab with the contents of crontab.txt.

In fact, I think that this is what may have happened on Tuesday, Nov
20, 2018, when suddenly there was no crontab any more.

Signed-off-by: Jeff Squyres <jeff@squyres.com>