### PR TITLE
Remove the crontab replacement script.

### DIFF
--- a/linux/every5/crontab.sh
+++ b/linux/every5/crontab.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-# Double check to make sure that the crontab file is not empty before
-# replacing it (i.e., the "-s" option).
-file="$BASE/crontab.txt"
-if test -f "$file" -a -s "$file"; then
-    crontab $file
-fi


### PR DESCRIPTION
It seems to have been the problem on March 14th; it set an empty
crontab which caused all data to stop collecting.

Signed-off-by: Jeff Squyres <jeff@squyres.com>