### PR TITLE
meraki rename: remove debugging statement

### DIFF
--- a/meraki-device-rename/magic.py
+++ b/meraki-device-rename/magic.py
@@ -102,7 +102,6 @@ for device in devices:
     }
 
     print(f"- Setting name for MAC {client_data['mac']}: {client_data['name']}")
-    continue
     response = dashboard.networks.provisionNetworkClients(
         meraki_network['id'], [ client_data ],
         meraki_policy_name)


### PR DESCRIPTION
Remove a debugging statement that was accidentally left in.

Signed-off-by: Jeff Squyres <jeff@squyres.com>