### PR TITLE
Python script to check if the firewall rules are setup properly

### DIFF
--- a/firewall/check-firewall-rules.py
+++ b/firewall/check-firewall-rules.py
@@ -1,0 +1,12 @@
+import csv
+
+# Import the CSV into a list of URLs
+blockedUrlFile = "blocked.csv"
+with open(blockedUrlFile, newline='') as csvFile:
+    urlReader - csv.DictReader(csvFile)
+
+# Go through the list and and remove any regex
+
+# Go through the sanitized list and see if we get the proper response back from
+# each one. (Success from allowed ones, failures from denied ones)
+

--- a/firewall/check-firewall-rules.py
+++ b/firewall/check-firewall-rules.py
@@ -1,12 +1,37 @@
 import csv
+import requests
+
+cleanedLinks = list()
 
 # Import the CSV into a list of URLs
 blockedUrlFile = "blocked.csv"
 with open(blockedUrlFile, newline='') as csvFile:
-    urlReader - csv.DictReader(csvFile)
-
-# Go through the list and and remove any regex
+    urlReader = csv.DictReader(csvFile)
+    # Go through the list and and remove any regex
+    for row in urlReader:
+        row["URL PATTERN"] = row["URL PATTERN"].strip("*.")
+        cleanedLinks.append(row)
 
 # Go through the sanitized list and see if we get the proper response back from
 # each one. (Success from allowed ones, failures from denied ones)
+for site in cleanedLinks:
+    url = f"https://{site['URL PATTERN']}"
+    name = site["NAME"]
+    denied = False
+    if site["ACTION"] == "Deny":
+        denied = True
+    try:
+        request = requests.get(url, timeout=1)
+        if denied:
+            response = f"FAIL: got through with response {request.status_code}"
+        else:
+            response = "SUCCESS: allowed"
+    except requests.Timeout as error:
+        if denied:
+            response = "SUCCESS: blocked"
+        else:
+            response = "FAIL: timed out when we shouldn't have"
+    except Exception as error:
+        response = f"something else went wrong... {error}"
+    print(f"{name}: {response}")
 


### PR DESCRIPTION
@jsquyres So I got it working... 'working' in the sense that it will test all the links. However, I think we may need to do some tweaking at Mercy. Some sites gave me errors I'm not sure what to do with - like aviary.com giving me this error:
```HTTPSConnectionPool(host='aviary.com', port=443): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f8739c2ca90>: Failed to establish a new connection: [Errno -5] No address associated with hostname'))```

Additionally, we'll probably have to play with the timeout value while we're there. From this [Meraki doc](https://documentation.meraki.com/MX/Firewall_and_Traffic_Shaping/Blocking_Websites_with_Content_Filtering_and_Layer_7_Firewall_Rules#Block_Page_is_Not_Displayed), it says that HTTPS requests will timeout instead of redirecting. So I think we'll have to find a balance between actually timing out and content blocking (and perhaps time).