### PR TITLE
Github action: update to reset actual Mercy 802.11x user

### DIFF
--- a/.github/workflows/meraki-password.yaml
+++ b/.github/workflows/meraki-password.yaml
@@ -2,7 +2,7 @@ name: Set Meraki password
 
 on:
   schedule:
-      - cron: "0 9 * * *"
+      - cron: "0 9 * * 1"
 
 jobs:
   change-password:
@@ -24,8 +24,4 @@ jobs:
       run: |
         cd meraki-80211x-users
         ./meraki-renew-user.py \
-            --api-key ${{ secrets.MERAKI_API_KEY }} \
-            --org 'Wailing Banshees' \
-            --network 'ChezSquyres' \
-            --ssid Yowza \
-            --email meraki.guest@squyres.com
+            --api-key ${{ secrets.MERAKI_API_KEY }}


### PR DESCRIPTION
Take us out of test mode: now update the actual Mercy 802.11x user instead of the test user.

Also, only run on Monday mornings.